### PR TITLE
Corrected pin offset (for other raspis than pi5)

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -83,6 +83,9 @@ module.exports = NodeHelper.create({
             Log.log(self.name + ": RPi5 detected");
             pinOffset = 571; // RPi5 has diffent pin numbering
         }
+        else {
+            pinOffset = 512; //offset for other raspis
+        }
 
         var options = { persistentWatch: true , activeLow: !!self.buttons[index].activeLow};
 


### PR DESCRIPTION
This module isn't currently working on (in my case) raspberry pi 4. 
When MM is started this error message is shown:

> [2025-05-10 09:03:49.013] [LOG]   MMM-Buttons: RPi model Raspberry Pi 4 Model B Rev 1.5
[2025-05-10 09:03:49.022] [ERROR] Whoops! There was an uncaught exception...
[2025-05-10 09:03:49.043] [ERROR] Error: EINVAL: invalid argument, write
    at Object.writeFileSync (node:fs:2426:20)
    at exportGpio (/home/user/MagicMirror/modules/MMM-Buttons/node_modules/onoff/onoff.js:18:8)
    at new Gpio (/home/user/MagicMirror/modules/MMM-Buttons/node_modules/onoff/onoff.js:172:36)
    at Class.intializeButton (/home/user/MagicMirror/modules/MMM-Buttons/node_helper.js:89:19)
    at Class.intializeButtons (/home/user/MagicMirror/modules/MMM-Buttons/node_helper.js:105:18)
    at Class.socketNotificationReceived (/home/user/MagicMirror/modules/MMM-Buttons/node_helper.js:28:18)
    at Socket.<anonymous> (/home/user/MagicMirror/js/node_helper.js:91:10)
    at Socket.onevent (/home/user/MagicMirror/node_modules/socket.io/dist/socket.js:462:26)
    at Socket._onpacket (/home/user/MagicMirror/node_modules/socket.io/dist/socket.js:430:22)
    at /home/user/MagicMirror/node_modules/socket.io/dist/client.js:214:24
    at process.processTicksAndRejections (node:internal/process/task_queues:85:11) {
  errno: -22,
  code: 'EINVAL',
  syscall: 'write'
}

Thanks to [this stack overflow thread,](https://stackoverflow.com/questions/78173749/use-raspberry-pi-4-gpio-with-node-js/78184108#78184108) I found that the pin offset for the Pi 5 is set, but not for every other Pi.

Added correct pin offset for other raspberry pis than the pi5.